### PR TITLE
Close FD 9 when running subprocess

### DIFF
--- a/ohmycron
+++ b/ohmycron
@@ -81,16 +81,17 @@ function run_under_flock {
   mkdir -p "$(dirname "$lockpath")"
   if flock -nx 9
   then
-    cd ~
-    for rc in /etc/profile /etc/bashrc ~/.profile ~/.bashrc
-    do
-      [[ -s $rc ]] || continue
-      set +o errexit +o nounset +o pipefail
-      source "$rc"
-      set -o errexit -o nounset -o pipefail
-    done
-    out "pid $$ at $(date -u +%FT%TZ)" > "$lockpath"
-    exec -- "$@"
+    ( exec 9>&-
+      cd ~
+      for rc in /etc/profile /etc/bashrc ~/.profile ~/.bashrc
+      do
+        [[ -s $rc ]] || continue
+        set +o errexit +o nounset +o pipefail
+        source "$rc"
+        set -o errexit -o nounset -o pipefail
+      done
+      out "pid $$ at $(date -u +%FT%TZ)" > "$lockpath"
+      exec -- "$@" )
   else
     [[ ! -s $lockpath ]] || msg "Previous lock holder: $(< "$lockpath")"
     err "Failed to lock $lockpath; is another copy running?"


### PR DESCRIPTION
This is one approach -- don't let the child process hold onto the lock.

http://unix.stackexchange.com/a/291451/39539
